### PR TITLE
Updated to AMQ Streams 1.3.0 CRDs

### DIFF
--- a/01_connect_loadaddr/brokered-address-space.yaml
+++ b/01_connect_loadaddr/brokered-address-space.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressSpace
 metadata:
   name: brokpubsub

--- a/01_connect_loadaddr/brokered-queue.yaml
+++ b/01_connect_loadaddr/brokered-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: Address
 metadata:
   name: brokpubsub.myqbrok

--- a/01_connect_loadaddr/plans/010-BrokeredInfraConfig-default.yaml
+++ b/01_connect_loadaddr/plans/010-BrokeredInfraConfig-default.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: enmasse
 spec:
-  version: 0.26-SNAPSHOT
   admin:
     resources:
       memory: 512Mi

--- a/01_connect_loadaddr/plans/010-StandardInfraConfig-default-minimal.yaml
+++ b/01_connect_loadaddr/plans/010-StandardInfraConfig-default-minimal.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: enmasse
 spec:
-  version: 0.26-SNAPSHOT
   admin:
     resources:
       memory: 512Mi

--- a/01_connect_loadaddr/plans/040-AddressPlan-brokered-queue.yaml
+++ b/01_connect_loadaddr/plans/040-AddressPlan-brokered-queue.yaml
@@ -1,15 +1,14 @@
-apiVersion: admin.enmasse.io/v1beta1
+apiVersion: admin.enmasse.io/v1beta2
 kind: AddressPlan
 metadata:
   name: brokered-queue
   labels:
     app: enmasse
-displayName: Brokered Queue
-displayOrder: 0
-shortDescription: Creates a queue on a broker.
-longDescription: Creates a queue on a broker.
-uuid: 69f82df8-0501-11e8-a0a8-507b9def37d9
-addressType: queue
-requiredResources:
-- name: broker
-  credit: 0.0
+spec:
+  displayName: Brokered Queue
+  displayOrder: 0
+  shortDescription: Creates a queue on a broker.
+  longDescription: Creates a queue on a broker.
+  addressType: queue
+  resources:
+    broker: 0.0

--- a/01_connect_loadaddr/plans/040-AddressPlan-brokered-topic.yaml
+++ b/01_connect_loadaddr/plans/040-AddressPlan-brokered-topic.yaml
@@ -1,16 +1,14 @@
-apiVersion: admin.enmasse.io/v1beta1
+apiVersion: admin.enmasse.io/v1beta2
 kind: AddressPlan
 metadata:
   name: brokered-topic
   labels:
     app: enmasse
-displayName: Brokered Topic
-displayOrder: 0
-shortDescription: Creates a topic on a broker.
-longDescription: Creates a topic on a broker.
-uuid: a991e6fc-0501-11e8-8230-507b9def37d9
-addressType: topic
-requiredResources:
-- name: broker
-  credit: 0.0
-
+spec:
+  displayName: Brokered Topic
+  displayOrder: 0
+  shortDescription: Creates a topic on a broker.
+  longDescription: Creates a topic on a broker.
+  addressType: topic
+  resources:
+    broker: 0.0

--- a/01_connect_loadaddr/plans/040-AddressPlan-standard-small-anycast.yaml
+++ b/01_connect_loadaddr/plans/040-AddressPlan-standard-small-anycast.yaml
@@ -1,15 +1,14 @@
-apiVersion: admin.enmasse.io/v1beta1
+apiVersion: admin.enmasse.io/v1beta2
 kind: AddressPlan
 metadata:
   name: standard-small-anycast
   labels:
     app: enmasse
-displayName: Small Anycast
-displayOrder: 0
-shortDescription: Creates a small anycast address.
-longDescription: Creates a small anycast address where messages go via a router that does not take ownership of the messages.
-uuid: eb62f1d6-db73-11e8-9570-d45ddf138840
-addressType: anycast
-requiredResources:
-- name: router
-  credit: 0.001
+spec:
+  displayName: Small Anycast
+  displayOrder: 0
+  shortDescription: Creates a small anycast address.
+  longDescription: Creates a small anycast address where messages go via a router that does not take ownership of the messages.
+  addressType: anycast
+  resources:
+    router: 0.001

--- a/01_connect_loadaddr/plans/040-AddressPlan-standard-small-multicast.yaml
+++ b/01_connect_loadaddr/plans/040-AddressPlan-standard-small-multicast.yaml
@@ -1,15 +1,14 @@
-apiVersion: admin.enmasse.io/v1beta1
+apiVersion: admin.enmasse.io/v1beta2
 kind: AddressPlan
 metadata:
   name: standard-small-multicast
   labels:
     app: enmasse
-displayName: Small Multicast
-displayOrder: 0
-shortDescription: Creates a small multicast address.
-longDescription: Creates a small multicast address where messages go via a router that does not take ownership of the messages.
-uuid: 363b10bc-db74-11e8-a528-d45ddf138840
-addressType: multicast
-requiredResources:
-- name: router
-  credit: 0.001
+spec:
+  displayName: Small Multicast
+  displayOrder: 0
+  shortDescription: Creates a small multicast address.
+  longDescription: Creates a small multicast address where messages go via a router that does not take ownership of the messages.
+  addressType: multicast
+  resources:
+    router: 0.001

--- a/01_connect_loadaddr/plans/040-AddressPlan-standard-small-queue.yaml
+++ b/01_connect_loadaddr/plans/040-AddressPlan-standard-small-queue.yaml
@@ -1,18 +1,15 @@
-apiVersion: admin.enmasse.io/v1beta1
+apiVersion: admin.enmasse.io/v1beta2
 kind: AddressPlan
 metadata:
   name: standard-small-queue
   labels:
     app: enmasse
-displayName: Small Queue
-displayOrder: 0
-shortDescription: Creates a small queue sharing underlying broker with other queues.
-longDescription: Creates a small queue sharing underlying broker with other queues.
-uuid: 0843743a-0503-11e8-91df-507b9def37d9
-addressType: queue
-requiredResources:
-- name: router
-  credit: 0.001
-- name: broker
-  credit: 0.01
-
+spec:
+  displayName: Small Queue
+  displayOrder: 0
+  shortDescription: Creates a small queue sharing underlying broker with other queues.
+  longDescription: Creates a small queue sharing underlying broker with other queues.
+  addressType: queue
+  resources:
+    router: 0.001
+    broker: 0.01

--- a/01_connect_loadaddr/plans/040-AddressPlan-standard-small-subscription.yaml
+++ b/01_connect_loadaddr/plans/040-AddressPlan-standard-small-subscription.yaml
@@ -1,18 +1,15 @@
-apiVersion: admin.enmasse.io/v1beta1
+apiVersion: admin.enmasse.io/v1beta2
 kind: AddressPlan
 metadata:
   name: standard-small-subscription
   labels:
     app: enmasse
-displayName: Small Subscription
-displayOrder: 0
-shortDescription: Creates a small durable subscription on a topic.
-longDescription: Creates a small durable subscription on a topic, which is then accessed as a distinct address.
-uuid: 6a567f0e-db73-11e8-9e09-d45ddf138840
-addressType: subscription
-requiredResources:
-- name: router
-  credit: 0.001
-- name: broker
-  credit: 0.01
-
+spec:
+  displayName: Small Subscription
+  displayOrder: 0
+  shortDescription: Creates a small durable subscription on a topic.
+  longDescription: Creates a small durable subscription on a topic, which is then accessed as a distinct address.
+  addressType: subscription
+  resources:
+    router: 0.001
+    broker: 0.01

--- a/01_connect_loadaddr/plans/040-AddressPlan-standard-small-topic.yaml
+++ b/01_connect_loadaddr/plans/040-AddressPlan-standard-small-topic.yaml
@@ -1,18 +1,15 @@
-apiVersion: admin.enmasse.io/v1beta1
+apiVersion: admin.enmasse.io/v1beta2
 kind: AddressPlan
 metadata:
   name: standard-small-topic
   labels:
     app: enmasse
-displayName: Small Topic
-displayOrder: 0
-shortDescription: Creates a small topic sharing underlying broker with other topics.
-longDescription: Creates a small topic sharing underlying broker with other topics.
-uuid: c10377e0-db72-11e8-91a3-d45ddf138840
-addressType: topic
-requiredResources:
-- name: router
-  credit: 0.001
-- name: broker
-  credit: 0.01
-
+spec:
+  displayName: Small Topic
+  displayOrder: 0
+  shortDescription: Creates a small topic sharing underlying broker with other topics.
+  longDescription: Creates a small topic sharing underlying broker with other topics.
+  addressType: topic
+  resources:
+    router: 0.001
+    broker: 0.01

--- a/01_connect_loadaddr/plans/050-AddressSpacePlan-brokered-single-broker.yaml
+++ b/01_connect_loadaddr/plans/050-AddressSpacePlan-brokered-single-broker.yaml
@@ -1,20 +1,18 @@
-apiVersion: admin.enmasse.io/v1beta1
+apiVersion: admin.enmasse.io/v1beta2
 kind: AddressSpacePlan
 metadata:
   name: brokered-single-broker
   labels:
     app: enmasse
-  annotations:
-    enmasse.io/defined-by: default
-displayName: Single Broker
-displayOrder: 0
-shortDescription: Single Broker instance
-longDescription: Single Broker plan where you can create an infinite number of queues until the system falls over.
-uuid: 5d5acf5c-0500-11e8-ab55-507b9def37d9
-addressSpaceType: brokered
-resources:
-- name: broker
-  max: 1.9 
-addressPlans:
-- brokered-queue
-- brokered-topic
+spec:
+  displayName: Single Broker
+  displayOrder: 0
+  shortDescription: Single Broker instance
+  longDescription: Single Broker plan where you can create an infinite number of queues until the system falls over.
+  addressSpaceType: brokered
+  infraConfigRef: default
+  resourceLimits:
+    broker: 1.9 
+  addressPlans:
+  - brokered-queue
+  - brokered-topic

--- a/01_connect_loadaddr/plans/050-AddressSpacePlan-standard-small.yaml
+++ b/01_connect_loadaddr/plans/050-AddressSpacePlan-standard-small.yaml
@@ -1,27 +1,23 @@
-apiVersion: admin.enmasse.io/v1beta1
+apiVersion: admin.enmasse.io/v1beta2
 kind: AddressSpacePlan
 metadata:
   name: standard-small
   labels:
     app: enmasse
-  annotations:
-    enmasse.io/defined-by: default-minimal
-displayName: Small
-displayOrder: 0
-shortDescription: Messaging infrastructure based on Apache Qpid Dispatch Router and Apache ActiveMQ Artemis
-longDescription: Messaging infrastructure based on Apache Qpid Dispatch Router and Apache ActiveMQ Artemis. This plan allows up to 1 router and 1 broker in total, and is suitable for small applications using small address plans and few addresses.
-uuid: f084d7f4-0501-11e8-a572-507b9def37d9
-addressSpaceType: standard
-resources:
-- name: router
-  max: 1.0
-- name: broker
-  max: 1.0
-- name: aggregate
-  max: 2.0
-addressPlans:
-- standard-small-anycast
-- standard-small-multicast
-- standard-small-queue
-- standard-small-topic
-- standard-small-subscription
+spec:
+  displayName: Small
+  displayOrder: 0
+  shortDescription: Messaging infrastructure based on Apache Qpid Dispatch Router and Apache ActiveMQ Artemis
+  longDescription: Messaging infrastructure based on Apache Qpid Dispatch Router and Apache ActiveMQ Artemis. This plan allows up to 1 router and 1 broker in total, and is suitable for small applications using small address plans and few addresses.
+  addressSpaceType: standard
+  infraConfigRef: default-minimal
+  resourceLimits:
+    router: 1.0
+    broker: 1.0
+    aggregate: 2.0
+  addressPlans:
+  - standard-small-anycast
+  - standard-small-multicast
+  - standard-small-queue
+  - standard-small-topic
+  - standard-small-subscription

--- a/01_connect_loadaddr/standard-address-space.yaml
+++ b/01_connect_loadaddr/standard-address-space.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressSpace
 metadata:
   name: pubsubproj

--- a/01_connect_loadaddr/standard-small-queue.yaml
+++ b/01_connect_loadaddr/standard-small-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: Address
 metadata:
   name: pubsubproj.myqueue

--- a/01_connect_loadaddr/user-example1.yaml
+++ b/01_connect_loadaddr/user-example1.yaml
@@ -1,4 +1,4 @@
-apiVersion: user.enmasse.io/v1alpha1
+apiVersion: user.enmasse.io/v1beta1
 kind: MessagingUser
 metadata:
   name: pubsubproj.user1

--- a/01_connect_loadaddr/user-exampleb.yaml
+++ b/01_connect_loadaddr/user-exampleb.yaml
@@ -1,4 +1,4 @@
-apiVersion: user.enmasse.io/v1alpha1
+apiVersion: user.enmasse.io/v1beta1
 kind: MessagingUser
 metadata:
   name: brokpubsub.userb

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # amq_enmasse_foundations_labs
+
 Scripts and lab exercises for amq_enmasse_foundations course


### PR DESCRIPTION
[Red Hat AMQ Online Foundations](https://learning.redhat.com/course/view.php?id=1255) course is not updated to the latest versions of:

- Red Hat AMQ Streams 1.3.0
- Red Hat OpenShift Container Platform 4.2+

I reviewed the current labs and they don't work in the latest versions, so I updated the CRs provided to the latest ones.

I tested the labs successfully to confirm them.

It would be great to update/adapt the current training course to the latest version of Red Hat AMQ Streams, otherwise most of the concepts are not valid.
